### PR TITLE
Fix session guard bypass, missing stderr redirects, and uninitialized…

### DIFF
--- a/usr/libexec/user-sysmaint-split/sysmaint-boot
+++ b/usr/libexec/user-sysmaint-split/sysmaint-boot
@@ -387,12 +387,12 @@ parse_user_sysmaint_split_config() {
 }
 
 remove_sysmaint_qubes() {
-   printf "%s\n" "INFO: Qubes unrestricted mode detected. Removing user-sysmaint-split."
-   printf "%s\n" "INFO: (kernel parameter 'remove-sysmaint-qubes' is present, ok.)"
+   printf "%s\n" "INFO: Qubes unrestricted mode detected. Removing user-sysmaint-split." >&2
+   printf "%s\n" "INFO: (kernel parameter 'remove-sysmaint-qubes' is present, ok.)" >&2
    dummy-dependency --yes --purge user-sysmaint-split
    if accountctl user is-pass-locked 2>/dev/null; then
-     printf "%s\n" "INFO: Account 'user' has a locked password. Running /usr/bin/passwordless-root to enable passwordless root escalation."
-     printf "%s\n" "INFO: (kernel parameter 'remove-sysmaint-qubes' is present, ok.)"
+     printf "%s\n" "INFO: Account 'user' has a locked password. Running /usr/bin/passwordless-root to enable passwordless root escalation." >&2
+     printf "%s\n" "INFO: (kernel parameter 'remove-sysmaint-qubes' is present, ok.)" >&2
      /usr/bin/passwordless-root
    fi
 }

--- a/usr/libexec/user-sysmaint-split/sysmaint-session
+++ b/usr/libexec/user-sysmaint-split/sysmaint-session
@@ -38,6 +38,8 @@ system_tray_list=(
 system_tray_arg_list=(
    '--edge top --align right --SetPartialStrut true'
 )
+selected_system_tray=''
+selected_system_tray_args=''
 
 for (( idx = 0; idx < ${#system_tray_list[@]}; idx++ )); do
    if [ -e "${system_tray_list[idx]}" ]; then

--- a/usr/libexec/user-sysmaint-split/sysmaint-session-wayland
+++ b/usr/libexec/user-sysmaint-split/sysmaint-session-wayland
@@ -80,6 +80,8 @@ system_tray_list=(
 system_tray_arg_list=(
    ''
 )
+selected_system_tray=''
+selected_system_tray_args=''
 
 for (( idx = 0; idx < ${#system_tray_list[@]}; idx++ )); do
    if [ -e "${system_tray_list[idx]}" ]; then

--- a/usr/share/user-sysmaint-split/conf/X11_Xsession.d_15_sysmaint_no_desktop
+++ b/usr/share/user-sysmaint-split/conf/X11_Xsession.d_15_sysmaint_no_desktop
@@ -4,7 +4,7 @@
 ## See the file COPYING for copying conditions.
 
 if [ "$(id -un)" = 'sysmaint' ] \
-   && ! printf '%s\n' 'sysmaint-session' | grep -- '^sysmaint-session' >/dev/null 2>/dev/null \
+   && ! printf '%s\n' "$DESKTOP_SESSION" | grep -- '^sysmaint-session' >/dev/null 2>/dev/null \
    && [ ! -f '/usr/share/qubes/marker-vm' ]; then
    TERMINAL_WRAPPER_NO_COMMAND_ECHO='true'
    export TERMINAL_WRAPPER_NO_COMMAND_ECHO

--- a/usr/share/user-sysmaint-split/conf/grub.d_10_10_linux_sysmaint
+++ b/usr/share/user-sysmaint-split/conf/grub.d_10_10_linux_sysmaint
@@ -16,15 +16,7 @@ make_boot_entry='true'
 : "${session_detail:="system maintenance tasks"}"
 
 grub_distributor_appendix="$persistence_type Mode | SYSMAINT Session | $session_detail"
-if [ -e '/usr/share/kicksecure/marker' ]; then
-   GRUB_DISTRIBUTOR="$grub_distributor_appendix"
-elif [ -e '/usr/share/anon-ws-base-files/workstation' ]; then
-   GRUB_DISTRIBUTOR="$grub_distributor_appendix"
-elif [ -e '/usr/share/anon-gw-base-files/gateway' ]; then
-   GRUB_DISTRIBUTOR="$grub_distributor_appendix"
-else
-   GRUB_DISTRIBUTOR="$grub_distributor_appendix"
-fi
+GRUB_DISTRIBUTOR="$grub_distributor_appendix"
 
 GRUB_DISABLE_RECOVERY="true"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX boot-role=sysmaint systemd.unit=sysmaint-boot.target"


### PR DESCRIPTION
… variables

- X11_Xsession.d_15_sysmaint_no_desktop: Fix always-false session check that compared hardcoded 'sysmaint-session' against itself instead of checking $DESKTOP_SESSION, completely bypassing the safety guard
- sysmaint-boot: Add missing >&2 redirects to printf statements in remove_sysmaint_qubes() so diagnostic messages go to stderr like all other messages in the script
- sysmaint-session, sysmaint-session-wayland: Initialize selected_system_tray and selected_system_tray_args to empty strings before the search loop to avoid referencing uninitialized variables
- grub.d_10_10_linux_sysmaint: Remove redundant if/elif/else where all branches assigned the same value

https://claude.ai/code/session_01QxHdBF7NnawVe5KW5cwttV

This pull request changes...

## Changes

## Mandatory Checklist

- [ ] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
